### PR TITLE
Add delete_previous_tag option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         prefix: test
+        delete_previous_tag: false
     - run: |
         if [[ -z "${BUILD_NUMBER}" ]]; then
           echo >&2 "BUILD_NUMBER environment variable is undefined!"
@@ -39,6 +40,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         prefix: test
+        delete_previous_tag: false
     - run: |
         if (-not (Test-Path env:BUILD_NUMBER)) {
           Write-Error "BUILD_NUMBER environment variable is undefined!"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ This will generate a git tag like `client-build-number-1`.
 
 If you then do the same in another workflow and use `prefix: server` then you'll get a second build-number tag called `server-build-number-1`.
 
+### Optional: Not deleting previous tags
+By default, the action deletes the previous build-number tag after creating a new one. If you want to keep all previous build-number tags, set `delete_previous_tag: false`:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Generate build number
+      uses: onyxmueller/build-tag-number@v1
+      with:
+        token: ${{secrets.github_token}}        
+        delete_previous_tag: false
+```
+
 ## Branches and build numbers
 
 The build number generator is global, there's no concept of special build numbers for special branches unless handled manually with the `prefix` property. It's probably something you would just use on builds from your master branch. It's just one number that gets increased every time the action is run.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   prefix:
     description: 'Prefix for the build-number-<num> tag to make it unique if tracking multiple build numbers'
     required: false
+  delete_previous_tag:
+    description: 'If set to false, previous build-number tags will not be deleted (default: true)'
+    required: false
 
 outputs:
   build_number:

--- a/main.js
+++ b/main.js
@@ -64,6 +64,7 @@ function main() {
 
     const path = 'BUILD_NUMBER/BUILD_NUMBER';
     const prefix = env.INPUT_PREFIX ? `${env.INPUT_PREFIX}-` : '';
+    const deletePreviousTag = env.INPUT_DELETE_PREVIOUS_TAG !== 'false';
 
     //See if we've already generated the build number and are in later steps...
     if (fs.existsSync(path)) {
@@ -136,7 +137,7 @@ function main() {
             fs.writeFileSync('BUILD_NUMBER', nextBuildNumber.toString());
             
             //Cleanup
-            if (nrTags) {
+            if (nrTags && deletePreviousTag) {
                 console.log(`Deleting ${nrTags.length} older build counters...`);
             
                 for (let nrTag of nrTags) {
@@ -148,6 +149,8 @@ function main() {
                         }
                     });
                 }
+            } else if (nrTags && !deletePreviousTag) {
+                console.log('Skipping deletion of previous build-number tags as requested.');
             }
 
         });


### PR DESCRIPTION
Add an option to control whether to delete previous build number tags. When set to false, the action will keep all previous build number tags instead of deleting them.